### PR TITLE
Add scope analysis

### DIFF
--- a/autopep695/analyzer.py
+++ b/autopep695/analyzer.py
@@ -53,6 +53,7 @@ def format_code(
     unsafe: bool,
     remove_variance: bool,
     remove_private: bool,
+    keep_assignments: bool,
 ) -> str:
     tree = _file_aware_parse_code(code, file_path)
     transformer = PEP695Formatter(
@@ -62,15 +63,21 @@ def format_code(
         remove_private=remove_private,
     )
     new_tree = tree.visit(transformer)
-    new_tree = new_tree.visit(
-        RemoveAssignments(set(transformer.unused_assignments.values()))
-    )
+    if not keep_assignments:
+        new_tree = new_tree.visit(
+            RemoveAssignments(set(transformer.unused_assignments.values()))
+        )
 
     return new_tree.code
 
 
 def _format_file(
-    path: Path, *, unsafe: bool, remove_variance: bool, remove_private: bool
+    path: Path,
+    *,
+    unsafe: bool,
+    remove_variance: bool,
+    remove_private: bool,
+    keep_assignments: bool,
 ) -> None:
     logging.debug("Analyzing file %s", format_special(path))
     with path.open("r+", encoding="utf-8") as f:
@@ -81,6 +88,7 @@ def _format_file(
                 unsafe=unsafe,
                 remove_variance=remove_variance,
                 remove_private=remove_private,
+                keep_assignments=keep_assignments,
             )
 
         except ParsingError:  # catch the exception so the file can be skipped and the whole process isn't terminated
@@ -99,7 +107,11 @@ def _format_file(
 
 
 def _format_file_wrapper(
-    unsafe: bool, remove_variance: bool, remove_private: bool, path: Path
+    unsafe: bool,
+    remove_variance: bool,
+    remove_private: bool,
+    keep_assignments: bool,
+    path: Path,
 ) -> None:
     """
     A `_format_file` wrapper that modifes the order of arguments.
@@ -112,6 +124,7 @@ def _format_file_wrapper(
         unsafe=unsafe,
         remove_variance=remove_variance,
         remove_private=remove_private,
+        keep_assignments=keep_assignments,
     )
 
 
@@ -122,6 +135,7 @@ def _parallel_format_paths(
     unsafe: bool,
     remove_variance: bool,
     remove_private: bool,
+    keep_assignments: bool,
 ) -> None:
     if processes is None:
         processes = os.cpu_count() or 1
@@ -147,7 +161,11 @@ def _parallel_format_paths(
         logging.debug("Run with --parallel, Starting %s processes...", processes)
         pool.map(
             functools.partial(
-                _format_file_wrapper, unsafe, remove_variance, remove_private
+                _format_file_wrapper,
+                unsafe,
+                remove_variance,
+                remove_private,
+                keep_assignments,
             ),
             paths,
         )
@@ -160,6 +178,7 @@ def format_paths(
     unsafe: bool,
     remove_variance: bool,
     remove_private: bool,
+    keep_assignments: bool,
 ) -> None:
     if parallel is not False:
         _parallel_format_paths(
@@ -168,6 +187,7 @@ def format_paths(
             unsafe=unsafe,
             remove_variance=remove_variance,
             remove_private=remove_private,
+            keep_assignments=keep_assignments,
         )
 
     else:
@@ -177,6 +197,7 @@ def format_paths(
                 unsafe=unsafe,
                 remove_variance=remove_variance,
                 remove_private=remove_private,
+                keep_assignments=keep_assignments,
             )
 
 

--- a/autopep695/analyzer.py
+++ b/autopep695/analyzer.py
@@ -62,7 +62,9 @@ def format_code(
         remove_private=remove_private,
     )
     new_tree = tree.visit(transformer)
-    new_tree = new_tree.visit(RemoveAssignments(set(transformer.unused_assignments.values())))
+    new_tree = new_tree.visit(
+        RemoveAssignments(set(transformer.unused_assignments.values()))
+    )
 
     return new_tree.code
 

--- a/autopep695/analyzer.py
+++ b/autopep695/analyzer.py
@@ -19,6 +19,7 @@ from autopep695.check import CheckPEP695Visitor
 from autopep695.format import PEP695Formatter
 from autopep695.ux import init_logging, format_special
 from autopep695.errors import ParsingError
+from autopep695.base import RemoveAssignments
 
 if t.TYPE_CHECKING:
     from pathlib import Path
@@ -61,6 +62,7 @@ def format_code(
         remove_private=remove_private,
     )
     new_tree = tree.visit(transformer)
+    new_tree = new_tree.visit(RemoveAssignments(set(transformer.unused_assignments.values())))
 
     return new_tree.code
 

--- a/autopep695/base.py
+++ b/autopep695/base.py
@@ -74,6 +74,7 @@ class TypingClassInfo:
     """
     The base class for collecting information about the usage of a `typing.X` or `typing_extensions.X` name.
     """
+
     name: str = field(init=False)
     """The original name to collect information about e.g. `TypeVar` or `TypeAlias`"""
     aliases: AliasCollection = field(default_factory=AliasCollection)
@@ -241,9 +242,12 @@ class TypeClassCollection:
     """
     A manager for all `TypingClassInfo` instances in a module:
     """
+
     __slots__: t.Sequence[str] = ("_data",)
 
-    def __init__(self, data: t.Optional[dict[type[TypingClassInfo], TypingClassInfo]]=None) -> None:
+    def __init__(
+        self, data: t.Optional[dict[type[TypingClassInfo], TypingClassInfo]] = None
+    ) -> None:
         self._data: dict[type[TypingClassInfo], TypingClassInfo] = data or {
             cls: cls() for cls in _typing_class_info_collection
         }
@@ -291,7 +295,6 @@ class TypeClassCollection:
             info.aliases.add_if_not_none(import_info.get(cls.name))
 
 
-
 @dataclass
 class TypeParamCollection(t.Generic[_SupportsTypeParameterT], abc.ABC):
     """
@@ -309,19 +312,23 @@ class TypeParamCollection(t.Generic[_SupportsTypeParameterT], abc.ABC):
         if self.node.type_parameters is None:
             return
 
-        names = t.cast(t.Sequence[cst.Name], m.findall(self.node.type_parameters, m.Name()))
+        names = t.cast(
+            t.Sequence[cst.Name], m.findall(self.node.type_parameters, m.Name())
+        )
         self.pep695_typeparameters = [name.value for name in names]
 
-    
+
 class ClassTypeParamCollection(TypeParamCollection[cst.ClassDef]):
     """
     Stores type parameters used in a python class
     """
 
+
 class FunctionTypeParamCollection(TypeParamCollection[cst.FunctionDef]):
     """
     Stores type parameters used in a python function
     """
+
 
 class ScopeContainer:
     """
@@ -331,13 +338,16 @@ class ScopeContainer:
     - class-level:      cst.ClassDef, any type parameter assignments that happened within
                         a class and are only available to nested classes and methods
 
-    - function-level:   cst.FunctionDef, any type parameter assignments that happened within 
+    - function-level:   cst.FunctionDef, any type parameter assignments that happened within
                         a function and are only available to nested classes and methods
     """
+
     def __init__(
-        self, 
-        node: t.Union[ClassTypeParamCollection, FunctionTypeParamCollection, cst.Module],
-        type_collection: t.Optional[TypeClassCollection]=None
+        self,
+        node: t.Union[
+            ClassTypeParamCollection, FunctionTypeParamCollection, cst.Module
+        ],
+        type_collection: t.Optional[TypeClassCollection] = None,
     ) -> None:
         self._node = node
 
@@ -348,9 +358,11 @@ class ScopeContainer:
         self._type_collection = TypeClassCollection(data=data)
 
     @property
-    def node(self) -> t.Union[ClassTypeParamCollection, FunctionTypeParamCollection, cst.Module]:
+    def node(
+        self,
+    ) -> t.Union[ClassTypeParamCollection, FunctionTypeParamCollection, cst.Module]:
         return self._node
-    
+
     @property
     def type_collection(self) -> TypeClassCollection:
         return self._type_collection
@@ -376,11 +388,13 @@ class BaseVisitor(m.MatcherDecoratableTransformer):
     @property
     def current_typecollection(self) -> TypeClassCollection:
         return self._scope_stack[-1].type_collection
-    
+
     @property
-    def current_node(self) -> t.Union[ClassTypeParamCollection, FunctionTypeParamCollection, cst.Module]:
+    def current_node(
+        self,
+    ) -> t.Union[ClassTypeParamCollection, FunctionTypeParamCollection, cst.Module]:
         return self._scope_stack[-1].node
-    
+
     @property
     def unused_assignments(self) -> dict[Symbol, cst.Assign]:
         return self._unused_assignments
@@ -390,11 +404,13 @@ class BaseVisitor(m.MatcherDecoratableTransformer):
             self._node_to_parent[child] = node
 
         return super().on_visit(node)
-    
+
     def visit_Module(self, node: cst.Module) -> None:
         self._scope_stack.append(ScopeContainer(node))
-    
-    def leave_Module(self, original_node: cst.Module, updated_node: cst.Module) -> cst.Module:
+
+    def leave_Module(
+        self, original_node: cst.Module, updated_node: cst.Module
+    ) -> cst.Module:
         self._scope_stack.pop()
         return updated_node
 
@@ -466,7 +482,7 @@ class BaseVisitor(m.MatcherDecoratableTransformer):
                         f"Type Error in {format_special(self._file_path)}: Can't assign variable {var_name} to {info.name}({e.arg_name!r})"
                     )
                     return False
-                
+
                 if self.should_ignore_assign(node):
                     # Since we ignore a valid type parameter assignment
                     # we need to make sure that if a symbol from outer scope with the same name exists
@@ -480,13 +496,15 @@ class BaseVisitor(m.MatcherDecoratableTransformer):
                 return True
 
         return False
-    
+
     def visit_Assign(self, node: cst.Assign) -> None:
         self._process_typeparam_assign(node)
 
     # We need to specify a `leave_Assign` because otherwise libcst defaults to creating a new `libcst.Assign` instance with a new memory address
     # This is not what we want, because when comparing assignment nodes in the second visitor pass, the IDs don't match and we can't remove unused assignments
-    def leave_Assign(self, original_node: cst.Assign, updated_node: cst.Assign) -> cst.Assign:
+    def leave_Assign(
+        self, original_node: cst.Assign, updated_node: cst.Assign
+    ) -> cst.Assign:
         return original_node
 
     def _assign_is_typealias(self, node: cst.AnnAssign) -> bool:
@@ -513,10 +531,12 @@ class BaseVisitor(m.MatcherDecoratableTransformer):
             original_node, self.current_typecollection.get(TypeVarInfo).symbols.values()
         )
         _used_paramspecs = self._resolve_assign_type_parameter_used(
-            original_node, self.current_typecollection.get(ParamSpecInfo).symbols.values()
+            original_node,
+            self.current_typecollection.get(ParamSpecInfo).symbols.values(),
         )
         _used_typevartuples = self._resolve_assign_type_parameter_used(
-            original_node, self.current_typecollection.get(TypeVarTupleInfo).symbols.values()
+            original_node,
+            self.current_typecollection.get(TypeVarTupleInfo).symbols.values(),
         )
 
         if ignore:
@@ -541,14 +561,20 @@ class BaseVisitor(m.MatcherDecoratableTransformer):
             remove_private=remove_private,
         )
         if remove_variance or remove_private:
-            new_node.with_changes(value=new_node.value.visit(CleanNameTransformer(self.current_typecollection, remove_variance, remove_private)))
+            new_node.with_changes(
+                value=new_node.value.visit(
+                    CleanNameTransformer(
+                        self.current_typecollection, remove_variance, remove_private
+                    )
+                )
+            )
 
         return new_node
-    
+
     def _should_ignore_comment(self, comment: t.Optional[cst.Comment]) -> bool:
         if comment is None:
             return False
-        
+
         return comment.value[1:].strip() in _IGNORE_COMMENTS_RULES
 
     def should_ignore_assign(self, node: t.Union[cst.Assign, cst.AnnAssign]) -> bool:
@@ -559,16 +585,17 @@ class BaseVisitor(m.MatcherDecoratableTransformer):
         )
 
         return self._should_ignore_comment(parent.trailing_whitespace.comment)
-    
-    def _should_ignore_compound_statement(self, node: cst.BaseCompoundStatement) -> bool:
+
+    def _should_ignore_compound_statement(
+        self, node: cst.BaseCompoundStatement
+    ) -> bool:
         body = ensure_type(node.body, cst.SimpleStatementSuite, cst.IndentedBlock)
 
         if isinstance(body, cst.SimpleStatementSuite):
             return self._should_ignore_comment(body.trailing_whitespace.comment)
-        
+
         else:
             return self._should_ignore_comment(body.header.comment)
-        
 
     def _contains_symbol_name(self, node: cst.CSTNode, sym: Symbol) -> bool:
         return bool(m.findall(node, m.Name(sym.name)))
@@ -613,29 +640,34 @@ class BaseVisitor(m.MatcherDecoratableTransformer):
             )
 
         return self._resolve_symbols_used(symbols, condition)
-    
+
     def update_param_collection(
-        self, 
+        self,
         collection: TypeParamCollection[_SupportsTypeParameterT],
         *,
         condition: t.Callable[[Symbol], bool],
         resolver: t.Callable[[_SupportsTypeParameterT, list[Symbol]], list[Symbol]],
-        ignore: bool
+        ignore: bool,
     ) -> None:
         pep695_typeparams: list[str] = []
         for param, param_collection in zip(
-            TYPE_PARAM_CLASSES, 
-            (collection.typevars_used, collection.paramspecs_used, collection.typevartuples_used)
+            TYPE_PARAM_CLASSES,
+            (
+                collection.typevars_used,
+                collection.paramspecs_used,
+                collection.typevartuples_used,
+            ),
         ):
             param_collection = t.cast(list[Symbol], param_collection)
             symbols = resolver(
-                collection.node, list(self.current_typecollection.get(param).symbols.values())
+                collection.node,
+                list(self.current_typecollection.get(param).symbols.values()),
             )
             new_symbols = [sym for sym in symbols if condition(sym)]
             if ignore is True:
                 for sym in new_symbols:
                     self._unused_assignments.pop(sym, None)
-                    pep695_typeparams.append(sym.name) 
+                    pep695_typeparams.append(sym.name)
                     # ugly hack to make sure the typevars are still accounted for in inner classes/functions
                     # can't put them in `*_used` because we don't want to transpile them later
 
@@ -644,10 +676,12 @@ class BaseVisitor(m.MatcherDecoratableTransformer):
 
         collection.pep695_typeparameters.extend(pep695_typeparams)
 
-
     def visit_ClassDef(self, node: cst.ClassDef) -> None:
         self._scope_stack.append(
-            ScopeContainer(ClassTypeParamCollection(node), type_collection=self.current_typecollection)
+            ScopeContainer(
+                ClassTypeParamCollection(node),
+                type_collection=self.current_typecollection,
+            )
         )
 
         collection = ensure_type(self.current_node, ClassTypeParamCollection)
@@ -655,16 +689,21 @@ class BaseVisitor(m.MatcherDecoratableTransformer):
             collection,
             condition=lambda sym: sym.name not in collection.pep695_typeparameters,
             resolver=self._resolve_class_type_parameter_used,
-            ignore=self._should_ignore_compound_statement(node)
+            ignore=self._should_ignore_compound_statement(node),
         )
 
-    def leave_ClassDef(self, original_node: cst.ClassDef, updated_node: cst.ClassDef) -> cst.ClassDef:
+    def leave_ClassDef(
+        self, original_node: cst.ClassDef, updated_node: cst.ClassDef
+    ) -> cst.ClassDef:
         self._scope_stack.pop()
         return updated_node
 
     def visit_FunctionDef(self, node: cst.FunctionDef) -> None:
         self._scope_stack.append(
-            ScopeContainer(FunctionTypeParamCollection(node), type_collection=self.current_typecollection)
+            ScopeContainer(
+                FunctionTypeParamCollection(node),
+                type_collection=self.current_typecollection,
+            )
         )
         collection = ensure_type(self.current_node, FunctionTypeParamCollection)
         _inherited_symbols: dict[type[Symbol], list[Symbol]] = {
@@ -673,7 +712,7 @@ class BaseVisitor(m.MatcherDecoratableTransformer):
             TypeVarTupleSymbol: [],
         }
         _inherited_pep695_names: list[str] = [*collection.pep695_typeparameters]
-        
+
         for container in reversed(self._scope_stack):
             if isinstance(container.node, cst.Module):
                 break
@@ -682,10 +721,12 @@ class BaseVisitor(m.MatcherDecoratableTransformer):
 
             _inherited_symbols[TypeVarSymbol].extend(container.node.typevars_used)
             _inherited_symbols[ParamSpecSymbol].extend(container.node.paramspecs_used)
-            _inherited_symbols[TypeVarTupleSymbol].extend(container.node.typevartuples_used)
+            _inherited_symbols[TypeVarTupleSymbol].extend(
+                container.node.typevartuples_used
+            )
 
             if isinstance(container.node, ClassTypeParamCollection):
-                break # Classes can't re-use type parameters
+                break  # Classes can't re-use type parameters
 
         self.update_param_collection(
             collection,
@@ -694,14 +735,15 @@ class BaseVisitor(m.MatcherDecoratableTransformer):
                 and sym not in _inherited_symbols[type(sym)]
             ),
             resolver=self._resolve_function_type_parameter_used,
-            ignore=self._should_ignore_compound_statement(node)
+            ignore=self._should_ignore_compound_statement(node),
         )
-        
 
-    def leave_FunctionDef(self, original_node: cst.FunctionDef, updated_node: cst.FunctionDef) -> cst.FunctionDef:
+    def leave_FunctionDef(
+        self, original_node: cst.FunctionDef, updated_node: cst.FunctionDef
+    ) -> cst.FunctionDef:
         self._scope_stack.pop()
         return updated_node
-    
+
     def add_typeparameters(
         self,
         original_node: _SupportsTypeParameterT,
@@ -729,7 +771,7 @@ class BaseVisitor(m.MatcherDecoratableTransformer):
                     self.current_typecollection.get(param_type).build(
                         symbol,
                         remove_variance=remove_variance,
-                        remove_private=remove_private
+                        remove_private=remove_private,
                     )
                 )
 
@@ -742,21 +784,26 @@ class ClassBaseArgTransformer(cst.CSTTransformer):
 
         super().__init__()
 
-    def leave_Arg(self, original_node: cst.Arg, updated_node: cst.Arg) -> t.Union[cst.Arg, cst.RemovalSentinel]:
+    def leave_Arg(
+        self, original_node: cst.Arg, updated_node: cst.Arg
+    ) -> t.Union[cst.Arg, cst.RemovalSentinel]:
         if not isinstance(original_node.value, cst.Subscript):
             return updated_node
-        
+
         name = get_qualified_name(original_node.value.value)
         if name in self._type_collection.get(GenericInfo).aliases:
             return cst.RemoveFromParent()
-        
+
         if name in self._type_collection.get(ProtocolInfo).aliases:
             return updated_node.with_changes(value=original_node.value.value)
 
         return updated_node
-    
+
+
 class CleanNameTransformer(cst.CSTTransformer):
-    def __init__(self, type_collection: TypeClassCollection, variance: bool, private: bool) -> None:
+    def __init__(
+        self, type_collection: TypeClassCollection, variance: bool, private: bool
+    ) -> None:
         self._type_collection = type_collection
         self._variance = variance
         self._private = private
@@ -767,16 +814,21 @@ class CleanNameTransformer(cst.CSTTransformer):
         for param in TYPE_PARAM_CLASSES:
             names = self._type_collection.get(param).symbols.keys()
             if original_node.value in names:
-                return cst.Name(make_clean_name(original_node.value, self._variance, self._private))
-            
+                return cst.Name(
+                    make_clean_name(original_node.value, self._variance, self._private)
+                )
+
         return updated_node
-    
+
+
 class RemoveAssignments(cst.CSTTransformer):
     def __init__(self, assignments: set[cst.Assign]) -> None:
         self._assignments = assignments
 
-    def leave_Assign(self, original_node: cst.Assign, updated_node: cst.Assign) -> t.Union[cst.Assign, cst.RemovalSentinel]:
+    def leave_Assign(
+        self, original_node: cst.Assign, updated_node: cst.Assign
+    ) -> t.Union[cst.Assign, cst.RemovalSentinel]:
         if original_node in self._assignments:
             return cst.RemoveFromParent()
-        
+
         return updated_node

--- a/autopep695/base.py
+++ b/autopep695/base.py
@@ -374,9 +374,9 @@ class BaseVisitor(m.MatcherDecoratableTransformer):
 
         self._node_to_parent: dict[cst.CSTNode, cst.CSTNode] = {}
         self._scope_stack: list[ScopeContainer] = []
-        # A stack to store the class or function we are currently in
-        # When visiting a class or function, the respective node will be pushed to the stack
-        # When leaving a class or a function, we will pop from the stack
+        # A stack to store entered scopes
+        # When visiting a module, class or function, the respective container is pushed onto the stack
+        # When leaving a module, class or function, we will pop() from the stack
 
         self._unused_assignments: dict[Symbol, cst.Assign] = {}
         # Mutable mapping that maps a symbol to the Assign node that it was created in

--- a/autopep695/base.py
+++ b/autopep695/base.py
@@ -71,8 +71,19 @@ _typing_class_info_collection: list[type[TypingClassInfo]] = []
 
 @dataclass
 class TypingClassInfo:
+    """
+    The base class for collecting information about the usage of a `typing.X` or `typing_extensions.X` name.
+    """
     name: str = field(init=False)
+    """The original name to collect information about e.g. `TypeVar` or `TypeAlias`"""
     aliases: AliasCollection = field(default_factory=AliasCollection)
+    """
+    Aliases for this name. Currently an alias can only be made from an import statement e.g.
+    import typing as t
+    from typing_extensions import ParamSpec
+
+    Creates the following aliases for `ParamSpec`: `t.ParamSpec`, `ParamSpec`.
+    """
 
     def __init_subclass__(cls) -> None:
         if not inspect.isabstract(cls):
@@ -82,6 +93,16 @@ class TypingClassInfo:
 @dataclass
 class TypingParameterClassInfo(t.Generic[_SymbolT], TypingClassInfo, abc.ABC):
     symbols: dict[str, _SymbolT] = field(default_factory=dict)
+    """
+    A mapping of symbol name to symbol instance. Example for `TypeVar`:
+    import typing as t
+
+    T = t.TypeVar("T")
+    R = t.TypeVar("R")
+
+    creates the following mapping for this module (unused TypeVar args/kwargs are left out):
+    {"T": TypeVarSymbol("T"), "R": TypeVarSymbol("R")}
+    """
 
     @abc.abstractmethod
     def build(
@@ -217,6 +238,9 @@ TYPE_PARAM_CLASSES = t.cast(
 
 
 class TypeClassCollection:
+    """
+    A manager for all `TypingClassInfo` instances in a module:
+    """
     __slots__: t.Sequence[str] = ("_data",)
 
     def __init__(self, data: t.Optional[dict[type[TypingClassInfo], TypingClassInfo]]=None) -> None:
@@ -241,6 +265,14 @@ class TypeClassCollection:
         return self._data[cls]
 
     def update_aliases(self, namespace: str = "") -> None:
+        """
+        Update aliases for all managed names.
+        namespace is an empty string if a star import has been made e.g.
+        from typing import * or from typing_extensions import *
+
+        namespace is not empty if a simple `import` statement was used e.g.
+        import typing -> namespace=typing, import typing as t -> namespace=t, import typing_extensions as A -> namespace=A
+        """
         if namespace != "":
             namespace += "."
 
@@ -248,6 +280,13 @@ class TypeClassCollection:
             info.aliases.add(f"{namespace}{cls.name}")
 
     def update_aliases_from_import_info(self, import_info: dict[str, str]) -> None:
+        """
+        Update aliases given a mapping of the original import name to the alias.
+        This happens if you import a specific name from `typing` or `typing_extensions` e.g.:
+        from typing import Mapping
+
+        If import_info = {"Mapping": "Mapping", "TypeVar": "T"} then this will add the alias "T" to the `TypeVarInfo` instance
+        """
         for cls, info in self._data.items():
             info.aliases.add_if_not_none(import_info.get(cls.name))
 
@@ -256,9 +295,7 @@ class TypeClassCollection:
 @dataclass
 class TypeParamCollection(t.Generic[_SupportsTypeParameterT], abc.ABC):
     """
-    A class that manages type parameters for python classes. This class stores info about:
-    - existing PEP695-like type parameters
-    - type parameters used in class bases
+    A class that manages type parameters for any node that supports pep695-like type parameters
     """
 
     node: _SupportsTypeParameterT
@@ -266,24 +303,14 @@ class TypeParamCollection(t.Generic[_SupportsTypeParameterT], abc.ABC):
     paramspecs_used: list[ParamSpecSymbol] = field(default_factory=list)
     typevartuples_used: list[TypeVarTupleSymbol] = field(default_factory=list)
 
-    @property
-    def pep695_typeparameters(self) -> list[str]:
-        if self.node.type_parameters is None:
-            return []
-        
-        params: list[str] = []
-        
-        for param in self.node.type_parameters.params:
-            params.append(param.param.name.value)
+    pep695_typeparameters: list[str] = field(init=False, default_factory=list)
 
-        return params
-    
-    def get_pep695_typeparameters(self) -> list[str]:
+    def __post_init__(self):
         if self.node.type_parameters is None:
-            return []
+            return
 
         names = t.cast(t.Sequence[cst.Name], m.findall(self.node.type_parameters, m.Name()))
-        return [name.value for name in names]
+        self.pep695_typeparameters = [name.value for name in names]
 
     
 class ClassTypeParamCollection(TypeParamCollection[cst.ClassDef]):
@@ -315,6 +342,9 @@ class ScopeContainer:
         self._node = node
 
         data = None if not type_collection else deepcopy(type_collection.data)
+        """
+        We want to deepcopy the data because we don't want the inner scope to add symbols or aliases to the outer scope
+        """
         self._type_collection = TypeClassCollection(data=data)
 
     @property
@@ -336,11 +366,24 @@ class BaseVisitor(m.MatcherDecoratableTransformer):
         # When visiting a class or function, the respective node will be pushed to the stack
         # When leaving a class or a function, we will pop from the stack
 
+        self._unused_assignments: dict[Symbol, cst.Assign] = {}
+        # Mutable mapping that maps a symbol to the Assign node that it was created in
+        # We need to keep track of this because we don't want to delete assignments that are important
+        # because the defined symbol is still used
+
         super().__init__()
 
     @property
     def current_typecollection(self) -> TypeClassCollection:
         return self._scope_stack[-1].type_collection
+    
+    @property
+    def current_node(self) -> t.Union[ClassTypeParamCollection, FunctionTypeParamCollection, cst.Module]:
+        return self._scope_stack[-1].node
+    
+    @property
+    def unused_assignments(self) -> dict[Symbol, cst.Assign]:
+        return self._unused_assignments
 
     def on_visit(self, node: cst.CSTNode) -> bool:
         for child in node.children:
@@ -397,7 +440,7 @@ class BaseVisitor(m.MatcherDecoratableTransformer):
             import_info = self._get_import_symbols(node)
             self.current_typecollection.update_aliases_from_import_info(import_info)
 
-    def _is_typeparam_assign(self, node: cst.Assign) -> bool:
+    def _process_typeparam_assign(self, node: cst.Assign) -> bool:
         if not m.matches(
             node,
             m.Assign(
@@ -423,17 +466,28 @@ class BaseVisitor(m.MatcherDecoratableTransformer):
                         f"Type Error in {format_special(self._file_path)}: Can't assign variable {var_name} to {info.name}({e.arg_name!r})"
                     )
                     return False
+                
+                if self.should_ignore_assign(node):
+                    # Since we ignore a valid type parameter assignment
+                    # we need to make sure that if a symbol from outer scope with the same name exists
+                    # it is still overriden which is why we need to remove the symbol from the mapping
+                    # so it is not encounted for when we inspect the type parameters used for classes and functions later
+                    info.symbols.pop(symbol.name, None)
+                    return False
 
                 info.symbols[symbol.name] = symbol
+                self._unused_assignments[symbol] = node
                 return True
 
         return False
     
     def visit_Assign(self, node: cst.Assign) -> None:
-        if self._should_ignore_statement(node):
-            return
+        self._process_typeparam_assign(node)
 
-        self._is_typeparam_assign(node)
+    # We need to specify a `leave_Assign` because otherwise libcst defaults to creating a new `libcst.Assign` instance with a new memory address
+    # This is not what we want, because when comparing assignment nodes in the second visitor pass, the IDs don't match and we can't remove unused assignments
+    def leave_Assign(self, original_node: cst.Assign, updated_node: cst.Assign) -> cst.Assign:
+        return original_node
 
     def _assign_is_typealias(self, node: cst.AnnAssign) -> bool:
         if not m.matches(node.annotation, m.Annotation(m.Attribute() | m.Name())):
@@ -443,17 +497,15 @@ class BaseVisitor(m.MatcherDecoratableTransformer):
 
         return name in self.current_typecollection.get(TypeAliasInfo).aliases
 
-    def maybe_build_TypeAlias_node(
+    def process_TypeAlias_node(
         self,
         original_node: cst.AnnAssign,
         updated_node: cst.AnnAssign,
         *,
+        ignore: bool,
         remove_variance: bool = False,
         remove_private: bool = False,
     ) -> t.Union[cst.AnnAssign, cst.TypeAlias]:
-        if self._should_ignore_statement(original_node):
-            return updated_node
-
         if not self._assign_is_typealias(original_node) or original_node.value is None:
             return updated_node
 
@@ -467,11 +519,19 @@ class BaseVisitor(m.MatcherDecoratableTransformer):
             original_node, self.current_typecollection.get(TypeVarTupleInfo).symbols.values()
         )
 
+        if ignore:
+            for sym in (*_used_typevars, *_used_paramspecs, *_used_typevartuples):
+                # if we are going to ignore the TypeAlias then the symbol is no longer unused
+                # and the type parameter assignment should not be deleted
+                self._unused_assignments.pop(sym, None)
+
+            return updated_node
+
         _TypeAliasNode = cst.TypeAlias(
             name=cst.ensure_type(original_node.target, cst.Name),
             value=original_node.value,
         )
-        new_node = self._add_typeparameters(
+        new_node = self.add_typeparameters(
             _TypeAliasNode,
             _TypeAliasNode,
             _used_typevars,
@@ -481,32 +541,34 @@ class BaseVisitor(m.MatcherDecoratableTransformer):
             remove_private=remove_private,
         )
         if remove_variance or remove_private:
-            for sym in (*_used_typevars, *_used_paramspecs, *_used_typevartuples):
-                new_node = m.replace(
-                    new_node,
-                    m.Name(sym.name),
-                    cst.Name(
-                        make_clean_name(
-                            sym.name, variance=remove_variance, private=remove_private
-                        )
-                    ),
-                )
+            new_node.with_changes(value=new_node.value.visit(CleanNameTransformer(self.current_typecollection, remove_variance, remove_private)))
 
-        return cst.ensure_type(new_node, cst.TypeAlias)
+        return new_node
+    
+    def _should_ignore_comment(self, comment: t.Optional[cst.Comment]) -> bool:
+        if comment is None:
+            return False
+        
+        return comment.value[1:].strip() in _IGNORE_COMMENTS_RULES
 
-    def _should_ignore_statement(self, node: cst.CSTNode) -> bool:
+    def should_ignore_assign(self, node: t.Union[cst.Assign, cst.AnnAssign]) -> bool:
         parent = ensure_type(
             self._node_to_parent[node],
             cst.SimpleStatementLine,
             cst.SimpleStatementSuite,
         )
 
-        if (
-            comment := parent.trailing_whitespace.comment
-        ) is not None and comment.value[1:].strip() in _IGNORE_COMMENTS_RULES:
-            return True
+        return self._should_ignore_comment(parent.trailing_whitespace.comment)
+    
+    def _should_ignore_compound_statement(self, node: cst.BaseCompoundStatement) -> bool:
+        body = ensure_type(node.body, cst.SimpleStatementSuite, cst.IndentedBlock)
 
-        return False
+        if isinstance(body, cst.SimpleStatementSuite):
+            return self._should_ignore_comment(body.trailing_whitespace.comment)
+        
+        else:
+            return self._should_ignore_comment(body.header.comment)
+        
 
     def _contains_symbol_name(self, node: cst.CSTNode, sym: Symbol) -> bool:
         return bool(m.findall(node, m.Name(sym.name)))
@@ -557,8 +619,10 @@ class BaseVisitor(m.MatcherDecoratableTransformer):
         collection: TypeParamCollection[_SupportsTypeParameterT],
         *,
         condition: t.Callable[[Symbol], bool],
-        resolver: t.Callable[[_SupportsTypeParameterT, list[Symbol]], list[Symbol]]
+        resolver: t.Callable[[_SupportsTypeParameterT, list[Symbol]], list[Symbol]],
+        ignore: bool
     ) -> None:
+        pep695_typeparams: list[str] = []
         for param, param_collection in zip(
             TYPE_PARAM_CLASSES, 
             (collection.typevars_used, collection.paramspecs_used, collection.typevartuples_used)
@@ -568,7 +632,17 @@ class BaseVisitor(m.MatcherDecoratableTransformer):
                 collection.node, list(self.current_typecollection.get(param).symbols.values())
             )
             new_symbols = [sym for sym in symbols if condition(sym)]
-            param_collection.extend(new_symbols)
+            if ignore is True:
+                for sym in new_symbols:
+                    self._unused_assignments.pop(sym, None)
+                    pep695_typeparams.append(sym.name) 
+                    # ugly hack to make sure the typevars are still accounted for in inner classes/functions
+                    # can't put them in `*_used` because we don't want to transpile them later
+
+            else:
+                param_collection.extend(new_symbols)
+
+        collection.pep695_typeparameters.extend(pep695_typeparams)
 
 
     def visit_ClassDef(self, node: cst.ClassDef) -> None:
@@ -576,16 +650,15 @@ class BaseVisitor(m.MatcherDecoratableTransformer):
             ScopeContainer(ClassTypeParamCollection(node), type_collection=self.current_typecollection)
         )
 
-        collection = ensure_type(self._scope_stack[-1].node, ClassTypeParamCollection)
+        collection = ensure_type(self.current_node, ClassTypeParamCollection)
         self.update_param_collection(
             collection,
             condition=lambda sym: sym.name not in collection.pep695_typeparameters,
-            resolver=self._resolve_class_type_parameter_used
+            resolver=self._resolve_class_type_parameter_used,
+            ignore=self._should_ignore_compound_statement(node)
         )
 
     def leave_ClassDef(self, original_node: cst.ClassDef, updated_node: cst.ClassDef) -> cst.ClassDef:
-        node = ensure_type(self._scope_stack[-1].node, ClassTypeParamCollection)
-        print(f"New typevars for class {original_node.name.value}: ", node.typevars_used)
         self._scope_stack.pop()
         return updated_node
 
@@ -593,7 +666,7 @@ class BaseVisitor(m.MatcherDecoratableTransformer):
         self._scope_stack.append(
             ScopeContainer(FunctionTypeParamCollection(node), type_collection=self.current_typecollection)
         )
-        collection = ensure_type(self._scope_stack[-1].node, FunctionTypeParamCollection)
+        collection = ensure_type(self.current_node, FunctionTypeParamCollection)
         _inherited_symbols: dict[type[Symbol], list[Symbol]] = {
             TypeVarSymbol: [],
             ParamSpecSymbol: [],
@@ -620,18 +693,16 @@ class BaseVisitor(m.MatcherDecoratableTransformer):
                 sym.name not in _inherited_pep695_names
                 and sym not in _inherited_symbols[type(sym)]
             ),
-            resolver=self._resolve_function_type_parameter_used
+            resolver=self._resolve_function_type_parameter_used,
+            ignore=self._should_ignore_compound_statement(node)
         )
         
 
     def leave_FunctionDef(self, original_node: cst.FunctionDef, updated_node: cst.FunctionDef) -> cst.FunctionDef:
-        node = ensure_type(self._scope_stack[-1].node, FunctionTypeParamCollection)
-        print(f"New typevars for function {original_node.name.value}: ", node.typevars_used)
         self._scope_stack.pop()
         return updated_node
     
-
-    def _add_typeparameters(
+    def add_typeparameters(
         self,
         original_node: _SupportsTypeParameterT,
         updated_node: _SupportsTypeParameterT,
@@ -649,58 +720,63 @@ class BaseVisitor(m.MatcherDecoratableTransformer):
         if original_node.type_parameters is not None:
             params = list(original_node.type_parameters.params)
 
-        for typevar in typevars:
-            params.append(
-                self.current_typecollection.get(TypeVarInfo).build(
-                    typevar,
-                    remove_variance=remove_variance,
-                    remove_private=remove_private,
+        for param_type, symbols_used in zip(
+            TYPE_PARAM_CLASSES,
+            (typevars, paramspecs, typevartuples),
+        ):
+            for symbol in symbols_used:
+                params.append(
+                    self.current_typecollection.get(param_type).build(
+                        symbol,
+                        remove_variance=remove_variance,
+                        remove_private=remove_private
+                    )
                 )
-            )
-
-        for typevartuple in typevartuples:
-            params.append(
-                self.current_typecollection.get(TypeVarTupleInfo).build(
-                    typevartuple,
-                    remove_variance=remove_variance,
-                    remove_private=remove_private,
-                )
-            )
-
-        for paramspec in paramspecs:
-            params.append(
-                self.current_typecollection.get(ParamSpecInfo).build(
-                    paramspec,
-                    remove_variance=remove_variance,
-                    remove_private=remove_private,
-                )
-            )
 
         return updated_node.with_changes(type_parameters=cst.TypeParameters(params))
 
 
-class RemoveGenericBaseMixin(m.MatcherDecoratableTransformer):
-    _type_collection: TypeClassCollection
+class ClassBaseArgTransformer(cst.CSTTransformer):
+    def __init__(self, type_collection: TypeClassCollection) -> None:
+        self._type_collection = type_collection
 
-    @m.call_if_inside(
-        m.ClassDef(bases=[m.AtLeastN(n=1)])
-    )  # Match type subscript in class base
-    def leave_Arg(
-        self, original_node: cst.Arg, updated_node: cst.Arg
-    ) -> t.Union[cst.Arg, cst.RemovalSentinel]:
-        if not m.matches(original_node, m.Arg(m.Subscript(m.Attribute() | m.Name()))):
+        super().__init__()
+
+    def leave_Arg(self, original_node: cst.Arg, updated_node: cst.Arg) -> t.Union[cst.Arg, cst.RemovalSentinel]:
+        if not isinstance(original_node.value, cst.Subscript):
             return updated_node
-
-        name = get_qualified_name(
-            cst.ensure_type(original_node.value, cst.Subscript).value
-        )
-
+        
+        name = get_qualified_name(original_node.value.value)
         if name in self._type_collection.get(GenericInfo).aliases:
             return cst.RemoveFromParent()
-
+        
         if name in self._type_collection.get(ProtocolInfo).aliases:
-            return updated_node.with_changes(
-                value=cst.ensure_type(original_node.value, cst.Subscript).value
-            )
+            return updated_node.with_changes(value=original_node.value.value)
 
+        return updated_node
+    
+class CleanNameTransformer(cst.CSTTransformer):
+    def __init__(self, type_collection: TypeClassCollection, variance: bool, private: bool) -> None:
+        self._type_collection = type_collection
+        self._variance = variance
+        self._private = private
+
+        super().__init__()
+
+    def leave_Name(self, original_node: cst.Name, updated_node: cst.Name) -> cst.Name:
+        for param in TYPE_PARAM_CLASSES:
+            names = self._type_collection.get(param).symbols.keys()
+            if original_node.value in names:
+                return cst.Name(make_clean_name(original_node.value, self._variance, self._private))
+            
+        return updated_node
+    
+class RemoveAssignments(cst.CSTTransformer):
+    def __init__(self, assignments: set[cst.Assign]) -> None:
+        self._assignments = assignments
+
+    def leave_Assign(self, original_node: cst.Assign, updated_node: cst.Assign) -> t.Union[cst.Assign, cst.RemovalSentinel]:
+        if original_node in self._assignments:
+            return cst.RemoveFromParent()
+        
         return updated_node

--- a/autopep695/base.py
+++ b/autopep695/base.py
@@ -561,7 +561,7 @@ class BaseVisitor(m.MatcherDecoratableTransformer):
             remove_private=remove_private,
         )
         if remove_variance or remove_private:
-            new_node.with_changes(
+            new_node = new_node.with_changes(
                 value=new_node.value.visit(
                     CleanNameTransformer(
                         self.current_typecollection, remove_variance, remove_private

--- a/autopep695/check.py
+++ b/autopep695/check.py
@@ -14,7 +14,12 @@ from libcst import matchers as m
 from libcst.metadata import PositionProvider, CodeRange
 
 from autopep695.ux import BOLD, RESET, YELLOW, RED, GREEN, format_special
-from autopep695.base import BaseVisitor, FunctionTypeParamCollection, ClassTypeParamCollection, ClassBaseArgTransformer
+from autopep695.base import (
+    BaseVisitor,
+    FunctionTypeParamCollection,
+    ClassTypeParamCollection,
+    ClassBaseArgTransformer,
+)
 from autopep695.helpers import ensure_type, make_empty_IndentedBlock
 
 if t.TYPE_CHECKING:
@@ -61,6 +66,7 @@ class FixFormattingTransformer(m.MatcherDecoratableTransformer):
     ) -> cst.FunctionDef:
         return updated_node.with_changes(body=make_empty_IndentedBlock())
 
+
 class FixClassDefFormattingTransformer(
     FixFormattingTransformer, ClassBaseArgTransformer
 ): ...
@@ -89,10 +95,13 @@ class CheckPEP695Visitor(BaseVisitor):
         assert isinstance(metadata, CodeRange)
         pos = metadata.start
         old_node = cst.ensure_type(
-            old_node.visit(FixFormattingTransformer(self.current_typecollection)), cst.CSTNode
+            old_node.visit(FixFormattingTransformer(self.current_typecollection)),
+            cst.CSTNode,
         )
         new_node = cst.ensure_type(
-            new_node.visit(FixClassDefFormattingTransformer(self.current_typecollection)),
+            new_node.visit(
+                FixClassDefFormattingTransformer(self.current_typecollection)
+            ),
             cst.CSTNode,
         )
         return Diagnostic(
@@ -130,7 +139,9 @@ class CheckPEP695Visitor(BaseVisitor):
     def _report_if_requires_change(
         self, node: t.Union[cst.FunctionDef, cst.ClassDef], message: str
     ) -> None:
-        collection = ensure_type(self.current_node, FunctionTypeParamCollection, ClassTypeParamCollection)
+        collection = ensure_type(
+            self.current_node, FunctionTypeParamCollection, ClassTypeParamCollection
+        )
         typevars = collection.typevars_used
         paramspecs = collection.paramspecs_used
         typevartuples = collection.typevartuples_used

--- a/autopep695/cli.py
+++ b/autopep695/cli.py
@@ -188,6 +188,12 @@ def main() -> None:
         required=False,
     )
     format_parser.add_argument(
+        "--keep-assignments",
+        help="Whether to keep unused type parameter assignments",
+        action="store_true",
+        required=False,
+    )
+    format_parser.add_argument(
         "-d",
         "--debug",
         help="Show debug information such as files analyzed",
@@ -245,6 +251,7 @@ def main() -> None:
                 unsafe=args.unsafe,
                 remove_variance=args.remove_variance,
                 remove_private=args.remove_private,
+                keep_assignments=args.keep_assignments,
             )
 
         except InvalidPath as e:

--- a/autopep695/format.py
+++ b/autopep695/format.py
@@ -5,47 +5,21 @@
 
 from __future__ import annotations
 
-import functools
 import typing as t
-from typing_extensions import ParamSpec, Concatenate
 
 import libcst as cst
-from libcst import matchers as m
 
 from autopep695.base import (
     BaseVisitor,
-    GenericInfo,
-    ProtocolInfo,
-    TYPE_PARAM_CLASSES,
-    Symbol,
-    make_clean_name,
+    ClassTypeParamCollection,
+    FunctionTypeParamCollection,
+    ClassBaseArgTransformer,
+    CleanNameTransformer
 )
-from autopep695.aliases import get_qualified_name
+from autopep695.helpers import ensure_type
 
 if t.TYPE_CHECKING:
     from pathlib import Path
-
-_T = t.TypeVar("_T")
-_P = ParamSpec("_P")
-_ClassT = t.TypeVar("_ClassT", bound="PEP695Formatter")
-
-
-def unsafe(
-    func: t.Callable[Concatenate[_ClassT, _P], _T],
-) -> t.Callable[Concatenate[_ClassT, _P], _T]:
-    """
-    A decorator to mark `leave_*` functions as unsafe.
-    The function will only run if the --unsafe flag was passed when running `autopep695 format`
-    """
-
-    @functools.wraps(func)
-    def inner(self: _ClassT, *args: _P.args, **kwargs: _P.kwargs) -> _T:
-        if self.unsafe is False:
-            return t.cast(_T, kwargs.get("updated_node") or args[1])
-
-        return func(self, *args, **kwargs)
-
-    return inner
 
 
 class PEP695Formatter(BaseVisitor):
@@ -57,110 +31,71 @@ class PEP695Formatter(BaseVisitor):
         remove_variance: bool,
         remove_private: bool,
     ) -> None:
-        self.unsafe = unsafe
+        self._unsafe = unsafe
 
         self._remove_variance = remove_variance
         self._remove_private = remove_private
 
         super().__init__(file_path=file_path)
 
-    def leave_Assign(
-        self, original_node: cst.Assign, updated_node: cst.Assign
-    ) -> t.Union[cst.RemovalSentinel, cst.Assign]:
-        if self._should_ignore_statement(original_node):
-            return updated_node
-
-        if self._is_typeparam_assign(original_node):
-            return cst.RemoveFromParent()
-
-        return updated_node
-
-    @unsafe
     def leave_AnnAssign(
         self, original_node: cst.AnnAssign, updated_node: cst.AnnAssign
     ) -> t.Union[cst.AnnAssign, cst.TypeAlias]:
-        return self.maybe_build_TypeAlias_node(
+        return self.process_TypeAlias_node(
             original_node,
             updated_node,
             remove_variance=self._remove_variance,
             remove_private=self._remove_private,
+            ignore=(not self._unsafe or self.should_ignore_assign(original_node))
         )
 
     def leave_FunctionDef(
         self, original_node: cst.FunctionDef, updated_node: cst.FunctionDef
     ) -> cst.FunctionDef:
-        return self._add_typeparameters(
-            original_node,
+        node = ensure_type(self.current_node, FunctionTypeParamCollection)
+        type_collection = self.current_typecollection
+        
+        super().leave_FunctionDef(original_node, updated_node)
+
+        if not any((node.typevars_used, node.paramspecs_used, node.typevartuples_used)):
+            return updated_node
+        
+        updated_node = ensure_type(updated_node.visit(CleanNameTransformer(type_collection, True, True)), cst.FunctionDef)
+        return self.add_typeparameters(
             updated_node,
-            self._new_typevars_for_node[original_node],
-            self._new_paramspecs_for_node[original_node],
-            self._new_typevartuples_for_node[original_node],
+            updated_node,
+            node.typevars_used,
+            node.paramspecs_used,
+            node.typevartuples_used,
             remove_variance=self._remove_variance,
-            remove_private=self._remove_private,
+            remove_private=self._remove_private
         )
 
     def leave_ClassDef(
         self, original_node: cst.ClassDef, updated_node: cst.ClassDef
     ) -> cst.ClassDef:
-        return self._add_typeparameters(
-            original_node,
+        node = ensure_type(self.current_node, ClassTypeParamCollection)
+        type_collection = self.current_typecollection
+
+        super().leave_ClassDef(original_node, updated_node)
+
+        if not any((node.typevars_used, node.paramspecs_used, node.typevartuples_used)):
+            return updated_node
+        
+        bases: list[t.Union[cst.Arg, cst.FlattenSentinel[cst.Arg]]] = []
+        for base in original_node.bases:
+            new_base = base.visit(ClassBaseArgTransformer(type_collection))
+            if not isinstance(new_base, cst.RemovalSentinel):
+                bases.append(new_base)
+
+        updated_node = updated_node.with_changes(bases=bases)
+        updated_node = ensure_type(updated_node.visit(CleanNameTransformer(type_collection, self._remove_variance, self._remove_private)), cst.ClassDef)
+        return self.add_typeparameters(
             updated_node,
-            self._new_typevars_for_node[original_node],
-            self._new_paramspecs_for_node[original_node],
-            self._new_typevartuples_for_node[original_node],
+            updated_node,
+            node.typevars_used,
+            node.paramspecs_used,
+            node.typevartuples_used,
             remove_variance=self._remove_variance,
-            remove_private=self._remove_private,
+            remove_private=self._remove_private
         )
-
-    def leave_Name(self, original_node: cst.Name, updated_node: cst.Name) -> cst.Name:
-        if not (self._remove_variance or self._remove_private):
-            return updated_node
-
-        def condition(sym: Symbol) -> bool:
-            return self._contains_symbol_name(original_node, sym)
-
-        for param in TYPE_PARAM_CLASSES:
-            info = self._type_collection.get(param)
-            if self._resolve_symbols_used(info.symbols, predicate=condition):
-                return cst.Name(
-                    make_clean_name(
-                        original_node.value,
-                        variance=self._remove_variance,
-                        private=self._remove_private,
-                    )
-                )
-
-        return updated_node
-
-    @m.call_if_inside(
-        m.ClassDef(bases=[m.AtLeastN(n=1)])
-    )  # Match type subscript in class base
-    def leave_Arg(
-        self, original_node: cst.Arg, updated_node: cst.Arg
-    ) -> t.Union[cst.Arg, cst.RemovalSentinel]:
-        if not m.matches(original_node, m.Arg(m.Subscript(m.Attribute() | m.Name()))):
-            return updated_node
-
-        subscript = cst.ensure_type(original_node.value, cst.Subscript)
-
-        name = get_qualified_name(subscript.value)
-
-        if name in self._type_collection.get(GenericInfo).aliases:
-            for param in TYPE_PARAM_CLASSES:
-                if self._resolve_symbols_used(
-                    self._type_collection.get(param).symbols,
-                    predicate=lambda sym: self._contains_symbol_name(subscript, sym),
-                ):
-                    return cst.RemoveFromParent()
-
-        if name in self._type_collection.get(ProtocolInfo).aliases:
-            for param in TYPE_PARAM_CLASSES:
-                if self._resolve_symbols_used(
-                    self._type_collection.get(param).symbols,
-                    predicate=lambda sym: self._contains_symbol_name(subscript, sym),
-                ):
-                    return updated_node.with_changes(
-                        value=cst.ensure_type(original_node.value, cst.Subscript).value
-                    )
-
-        return updated_node

--- a/autopep695/helpers.py
+++ b/autopep695/helpers.py
@@ -24,6 +24,7 @@ def ensure_type(obj: object, *types: Unpack[tuple[type[T], ...]]) -> T:
 
     return obj
 
+
 def make_clean_name(name: str, variance: bool, private: bool) -> str:
     if private:
         name = name.lstrip("_")
@@ -34,6 +35,7 @@ def make_clean_name(name: str, variance: bool, private: bool) -> str:
 
     return name
 
+
 def get_code(*nodes: cst.CSTNode) -> str:
     reprs: list[str] = []
     module = cst.Module(body=())
@@ -43,7 +45,6 @@ def get_code(*nodes: cst.CSTNode) -> str:
 
     return ", ".join(reprs)
 
+
 def make_empty_IndentedBlock() -> cst.IndentedBlock:
-    return cst.IndentedBlock(
-        body=[cst.SimpleStatementLine([cst.Expr(cst.Ellipsis())])]
-    )
+    return cst.IndentedBlock(body=[cst.SimpleStatementLine([cst.Expr(cst.Ellipsis())])])

--- a/autopep695/helpers.py
+++ b/autopep695/helpers.py
@@ -8,7 +8,7 @@ from typing_extensions import Unpack
 
 T = t.TypeVar("T")
 
-__all__: t.Sequence[str] = ("ensure_type",)
+__all__: t.Sequence[str] = ("ensure_type", "make_clean_name")
 
 
 def ensure_type(obj: object, *types: Unpack[tuple[type[T], ...]]) -> T:
@@ -21,3 +21,13 @@ def ensure_type(obj: object, *types: Unpack[tuple[type[T], ...]]) -> T:
         )
 
     return obj
+
+def make_clean_name(name: str, variance: bool, private: bool) -> str:
+    if private:
+        name = name.lstrip("_")
+
+    if variance:
+        name = name.removesuffix("_co")
+        name = name.removesuffix("_contra")
+
+    return name

--- a/autopep695/helpers.py
+++ b/autopep695/helpers.py
@@ -6,6 +6,8 @@
 import typing as t
 from typing_extensions import Unpack
 
+import libcst as cst
+
 T = t.TypeVar("T")
 
 __all__: t.Sequence[str] = ("ensure_type", "make_clean_name")
@@ -31,3 +33,17 @@ def make_clean_name(name: str, variance: bool, private: bool) -> str:
         name = name.removesuffix("_contra")
 
     return name
+
+def get_code(*nodes: cst.CSTNode) -> str:
+    reprs: list[str] = []
+    module = cst.Module(body=())
+
+    for node in nodes:
+        reprs.append(module.code_for_node(node))
+
+    return ", ".join(reprs)
+
+def make_empty_IndentedBlock() -> cst.IndentedBlock:
+    return cst.IndentedBlock(
+        body=[cst.SimpleStatementLine([cst.Expr(cst.Ellipsis())])]
+    )

--- a/autopep695/symbols.py
+++ b/autopep695/symbols.py
@@ -18,11 +18,17 @@ __all__: t.Sequence[str] = (
 )
 
 
+@t.runtime_checkable
 class Symbol(t.Protocol):
     name: str
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Symbol):
+            return False
+        
+        return self.name == other.name
 
-@dataclass(frozen=True, repr=False)
+@dataclass(frozen=True, repr=False, eq=False)
 class TypeVarSymbol(Symbol):
     name: str
     constraints: list[cst.BaseExpression]
@@ -37,20 +43,23 @@ class TypeVarSymbol(Symbol):
             constraints_repr.append(repr_string)
 
         bound_repr = "None"
+        default_repr = "None"
 
         if self.bound is not None:
             bound_repr = empty_module.code_for_node(self.bound)
 
-        return f"TypeVar(name={self.name!r}, constraints=({', '.join(constraints_repr)}), bound={bound_repr})"
+        if self.default is not None:
+            default_repr = empty_module.code_for_node(self.default)
+
+        return f"TypeVar(name={self.name!r}, constraints=({', '.join(constraints_repr)}), bound={bound_repr}, default={default_repr})"
 
 
-@dataclass(frozen=True, repr=False)
+@dataclass(frozen=True, repr=False, eq=False)
 class TypeVarTupleSymbol(Symbol):
     name: str
     default: t.Optional[cst.BaseExpression]
 
-
-@dataclass(frozen=True, repr=False)
+@dataclass(frozen=True, repr=False, eq=False)
 class ParamSpecSymbol(Symbol):
     name: str
     default: t.Optional[cst.BaseExpression]

--- a/autopep695/symbols.py
+++ b/autopep695/symbols.py
@@ -28,21 +28,22 @@ class Symbol(t.Protocol):
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Symbol):
             return False
-        
+
         return self.name == other.name
-    
+
     def __deepcopy__(self, memo: object) -> Self:
         """
         Return self as the instance is practically immutable
         """
         return self
-    
+
     def __hash__(self) -> int:
         """
         The data for a symbol is practically immutable which is why
         it should be fine to implement an "unsafe" hash
         """
         return id(self)
+
 
 @dataclass(frozen=True, repr=False, eq=False)
 class TypeVarSymbol(Symbol):
@@ -67,6 +68,7 @@ class TypeVarTupleSymbol(Symbol):
         default_repr = get_code(self.default) if self.default else "None"
 
         return f"TypeVarTuple(name={self.name!r}, default={default_repr})"
+
 
 @dataclass(frozen=True, repr=False, eq=False)
 class ParamSpecSymbol(Symbol):


### PR DESCRIPTION
### Summary
This PR introduces major changes to the internals of `autopep695`.
The following features were added:
- proper scope analysis using "scope containers" that can differentiate between names defined at module, class and function level and account for type parameter overrides (which was not possible before see #8)
- a two-pass-transpiler that tracks unused type parameter assignments in the first pass and removes them in the second pass
- A flag `--keep-assignments` that keeps unused assignments and prevents the transpiler from doing a second pass
- The ability to ignore any type parameter related statement using ` # pep695-ignore`, not only assignments: You can now ignore class and function type parameters, however that doesn't mean that inner functions and classes are ignored as well, you have to ignore them seperately
- A proper solution to removing `Generic` as base and the subscript from `Protocol` without potentially making changes in the class body too
- `TypeVarTupleSymbol` and `ParamSpecSymbol` now have a `__repr__` implementation just like `TypeVarSymbol`

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.

### Related issues
Closes #7
Closes #8 